### PR TITLE
feature(rafiki): make node env dynamic also on frontend package and bump versions

### DIFF
--- a/charts/rafiki-auth/Chart.yaml
+++ b/charts/rafiki-auth/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rafiki-auth/Chart.yaml
+++ b/charts/rafiki-auth/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.4.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 'v1.0.0-alpha.5'
+appVersion: 'v1.0.0-alpha.7'

--- a/charts/rafiki-auth/values.yaml
+++ b/charts/rafiki-auth/values.yaml
@@ -27,7 +27,7 @@ workers:
   cleanup: 1
 image:
   repository: ghcr.io/interledger/rafiki-auth
-  tag: 'v1.0.0-alpha.3'
+  tag: 'v1.0.0-alpha.7'
   digest: ''
   pullPolicy: IfNotPresent
 rollingUpdate:

--- a/charts/rafiki-backend/Chart.yaml
+++ b/charts/rafiki-backend/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rafiki-backend/Chart.yaml
+++ b/charts/rafiki-backend/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.4.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 'v1.0.0-alpha.5'
+appVersion: 'v1.0.0-alpha.7'

--- a/charts/rafiki-backend/values.yaml
+++ b/charts/rafiki-backend/values.yaml
@@ -50,7 +50,7 @@ idempotency:
   keyLock: 2000
 image:
   repository: ghcr.io/interledger/rafiki-backend
-  tag: 'v1.0.0-alpha.3'
+  tag: 'v1.0.0-alpha.7'
   digest: ''
   pullPolicy: IfNotPresent
 rollingUpdate:

--- a/charts/rafiki-frontend/Chart.yaml
+++ b/charts/rafiki-frontend/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rafiki-frontend/Chart.yaml
+++ b/charts/rafiki-frontend/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.4.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 'v1.0.0-alpha.5'
+appVersion: 'v1.0.0-alpha.7'

--- a/charts/rafiki-frontend/templates/configmap.yaml
+++ b/charts/rafiki-frontend/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
 data: 
   GRAPHQL_URL: "{{ .Values.serviceUrls.GRAPHQL_URL}}"
   LOG_LEVEL: debug
-  NODE_ENV: development
+  NODE_ENV: "{{ .Values.nodeEnv }}"
   PORT: "{{ .Values.port }}"

--- a/charts/rafiki-frontend/values.yaml
+++ b/charts/rafiki-frontend/values.yaml
@@ -1,3 +1,4 @@
+nodeEnv: development
 serviceUrls:
   GRAPHQL_URL: http://rafiki-backend:3001/graphql
 port: 3010

--- a/charts/rafiki-frontend/values.yaml
+++ b/charts/rafiki-frontend/values.yaml
@@ -4,7 +4,7 @@ serviceUrls:
 port: 3010
 image:
   repository: ghcr.io/interledger/rafiki-frontend
-  tag: 'v1.0.0-alpha.3'
+  tag: 'v1.0.0-alpha.7'
   digest: ''
   pullPolicy: IfNotPresent
 rollingUpdate:


### PR DESCRIPTION
This PR does basically just two things:
* bump versions of all three Rafiki packages to 1.0.0-alpha.7
* have NODE_ENV variable dynamic through values file for the frontend package, the same way as it is for auth and backend package

For production:
```
❯ helm template --release-name rafiki-frontend -s templates/configmap.yaml . --set nodeEnv=production
---
# Source: rafiki-frontend/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: rafiki-frontend
  labels: 
    app: rafiki-frontend
    app.kubernetes.io/name: rafiki-frontend
    helm.sh/chart: rafiki-frontend-0.4.0
    app.kubernetes.io/instance: rafiki-frontend
    app.kubernetes.io/version: "v1.0.0-alpha.7"
    app.kubernetes.io/managed-by: Helm
data: 
  GRAPHQL_URL: "http://rafiki-backend:3001/graphql"
  LOG_LEVEL: debug
  NODE_ENV: "production"
  PORT: "3010"
```

