### PR TITLE
chore(github): add issue template for bug report and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: 'type: bug'
+assignees: ''
+
+---
+
+Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+
+## Bug Report
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps and commands to reproduce the behavior. Please provide clear code snippets that always reproduce the bug.
+1. run 'helm template ...'
+2. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**General information (please complete the following information):**
+ - Chart name that has a problem
+ - Chart version
+ - App version
+ - Helm version: [output of `helm version`]
+ - Kubectl version: [output of `kubectl version`]
+ - Cloud Provider/Platform (GKE, EKS, AKS, Minikube etc.):
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE REQUEST]"
+labels: 'discussions: ideas'
+assignees: ''
+
+---
+
+Thanks for taking the time to file a feature request! Please fill out this form as completely as possible.
+
+Note that feature requests will be converted to the GitHub Discussions "Ideas" section.
+
+## Feature Request
+
+**Describe the feature you'd like to request**
+
+A clear and concise description of what you want and what your use case is.
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
For feature request, template is the same as it is in interledger/rafiki repository.

For reporting bugs, template is also the same, but, we are requesting different informations like kubectl and helm versions.

However, all feature requests in rafiki are transformed into discussion. I see that here, we do not have discussion enabled. Can we enable it maybe?