### PR TITLE
feat: add resource definitions for all packages

### DIFF
--- a/charts/rafiki-auth/Chart.yaml
+++ b/charts/rafiki-auth/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rafiki-auth/templates/deployment.yaml
+++ b/charts/rafiki-auth/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
                name: {{ include "rafiki-auth.fullname" . }}
            - secretRef:
                name: {{ include "rafiki-auth.fullname" . }}-secrets
+          {{- with .Values.initContainerResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -71,7 +75,7 @@ spec:
             - name: introspection
               containerPort: {{ .Values.port.introspection }}
               protocol: TCP
-          {{- with .Values.resources -}}
+          {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
-          {{- end -}}
+          {{- end }}

--- a/charts/rafiki-auth/values.yaml
+++ b/charts/rafiki-auth/values.yaml
@@ -47,10 +47,17 @@ serviceAccount:
   name: ''
 securityContext:
   {}
-#  resources:
-#    limits:
-#      memory: 1Gi
-#      cpu: 450m
-#    requests:
-#      memory: 800Mi
-#      cpu: 300m
+resources:
+  limits:
+    memory: 1Gi
+    cpu: 450m
+  requests:
+    memory: 800Mi
+    cpu: 300m
+initContainerResources:
+  limits:
+    memory: 512Mi
+    cpu: 250m
+  requests:
+    memory: 256Mi
+    cpu: 100m

--- a/charts/rafiki-backend/Chart.yaml
+++ b/charts/rafiki-backend/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rafiki-backend/templates/deployment.yaml
+++ b/charts/rafiki-backend/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
                name: {{ include "rafiki-backend.fullname" . }}
            - secretRef:
                name: {{ include "rafiki-backend.fullname" . }}-secrets
+          {{- with .Values.initContainerResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/rafiki-backend/values.yaml
+++ b/charts/rafiki-backend/values.yaml
@@ -64,10 +64,17 @@ serviceAccount:
   name: ''
 securityContext:
   {}
-#  resources:
-#    limits:
-#      memory: 1Gi
-#      cpu: 450m
-#    requests:
-#      memory: 800Mi
-#      cpu: 300m
+resources:
+  limits:
+    memory: 1Gi
+    cpu: 450m
+  requests:
+    memory: 800Mi
+    cpu: 300m
+initContainerResources:
+  limits:
+    memory: 512Mi
+    cpu: 250m
+  requests:
+    memory: 256Mi
+    cpu: 100m

--- a/charts/rafiki-frontend/Chart.yaml
+++ b/charts/rafiki-frontend/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rafiki-frontend/values.yaml
+++ b/charts/rafiki-frontend/values.yaml
@@ -18,6 +18,13 @@ serviceAccount:
   name: ''
 securityContext:
   {}
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 250m
+  requests:
+    memory: 256Mi
+    cpu: 100m
 kratos:
   containerPublicUrl:
   browserPublicUrl:


### PR DESCRIPTION
## PR Description

### **Define resources for all packages** 

Addresses issue #29 by adding Kubernetes resource definitions to prevent unlimited resource consumption.

### 📋 **Changes Made**

**Resource definitions added to all charts:**
- **rafiki-auth**: 1Gi memory / 450m CPU (main), 512Mi / 250m CPU (init containers)
- **rafiki-backend**: 1Gi memory / 450m CPU (main), 512Mi / 250m CPU (init containers)  
- **rafiki-frontend**: 512Mi memory / 250m CPU (main)

**Files modified:**
- `charts/rafiki-auth/values.yaml` & `templates/deployment.yaml`
- `charts/rafiki-backend/values.yaml` & `templates/deployment.yaml`
- `charts/rafiki-frontend/values.yaml`

### ✅ **Validation**
- Helm lint passed for all charts
- Template rendering verified
- Follows Kubernetes best practices (requests < limits for QoS Burstable class)

### 🔗 **Issue**
Closes #29

---
